### PR TITLE
common/#9: 헤더 컴포넌트 구현

### DIFF
--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
 import Button from '../Button';
 import SelectBox from './SelectBox';
 
@@ -12,31 +13,39 @@ export default function Header(props: HeaderProps) {
   const { title, isBoard = false, isOwner = false } = props;
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
-  const onClickArrowButton = () => alert('back arrow');
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const onClickArrowButton = () => {
+    if (location.pathname.includes('/bomb')) return navigate(-2);
+    return navigate(-1);
+  };
 
   const onClickDot3 = () => setIsDropdownOpen(true);
 
   const onClickDelete = () => {
     setIsDropdownOpen(false);
     alert('trash');
+    // TODO: 게시글 삭제 요청
+    navigate(-1);
   };
 
   return (
     <header className="w-full p-[1.2rem] flex justify-between items-center bg-green-3 text-green-1 text-1 font-regular">
       <div className="w-[5.3rem] flex items-center">
         {isBoard || (
-          <Button type="header" iconName="arrow" onClick={onClickArrowButton} />
+          <Button kind="header" iconName="arrow" onClick={onClickArrowButton} />
         )}
       </div>
       <h1>{title}</h1>
       <div className="w-[5.3rem] flex justify-end items-center relative">
         {isOwner && (
           <>
-            <Button type="header" iconName="dot" onClick={onClickDot3} />
+            <Button kind="header" iconName="dot" onClick={onClickDot3} />
             {isDropdownOpen && (
               <div className="absolute top-full right-0 mt-[0.4rem] w-[7.4rem]">
                 <Button
-                  type="delete"
+                  kind="delete"
                   iconName="trash"
                   onClick={onClickDelete}
                 />

--- a/src/components/common/header/SelectBox.tsx
+++ b/src/components/common/header/SelectBox.tsx
@@ -1,6 +1,26 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
 export default function SelectBox() {
+  const [sortBy, setSortBy] = useState('default');
+
+  const navigate = useNavigate();
+
+  const onChangeSelectBox = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const changedSortBy = e.target.value;
+    navigate(`/board?sort=${changedSortBy}`);
+    setSortBy(changedSortBy);
+  };
+
+  // TODO: sortBy 사용해서 데이터 20개씩 호출
+  console.log('sortBy', sortBy);
+
   return (
-    <select name="sort" id="sort" className="bg-inherit font-regular text-3">
+    <select
+      name="sort"
+      id="sort"
+      className="bg-inherit font-regular text-3"
+      onChange={onChangeSelectBox}>
       <option value="default">기본</option>
       <option value="popular">인기순</option>
       <option value="view">조회순</option>


### PR DESCRIPTION
### 🖼️ Screen shot

https://github.com/user-attachments/assets/17236068-985f-446d-97d8-e17cdbb25810

### 📝 Details

- 셀렉트 박스에서 정렬 기준 선택 시 `?sort=${기준}` 쿼리 스트링이 붙는다.
  - 기본(default), 인기순(popular), 조회순(view)
- 내가 작성한 게시글 삭제 시 전전 페이지인 대나무숲 페이지나 해우소 페이지로 이동
- 게시글에 존재할 때, 게시글이 폭파된다면 전전 페이지인 대나무숲 페이지나 해우소 페이지로 이동


### ⚠️ 주의사항

- 아직 백엔드 호출 없음


### 💬 Thinking

- 게시글을 삭제했거나 폭파 페이지를 방문할 경우, 다른 처리 없이 `navigate(-2)`를 통해서 전전 페이지로 이동하는데 로컬 스토리지를 사용하는 방법으로 바꿀지는 고민 중