### PR TITLE
common/#13: 남은 헤더 기능 구현

### DIFF
--- a/src/components/common/Bulletin.tsx
+++ b/src/components/common/Bulletin.tsx
@@ -4,7 +4,7 @@ import EmojiList from './EmojiList';
 interface BulletinProps {
   title: string;
   content: string;
-  time: number | string;
+  time?: number | string;
   reactions: ReactionListTextType;
   userReaction: null | keyof ReactionListTextType;
   isBoardDetail?: boolean;
@@ -12,6 +12,7 @@ interface BulletinProps {
   isShowZero?: boolean;
 }
 
+// TODO: time에 대한 시간 처리 해야함
 export default function Bulletin(props: BulletinProps) {
   const {
     title,

--- a/src/components/common/BulletinList.tsx
+++ b/src/components/common/BulletinList.tsx
@@ -1,0 +1,44 @@
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import Bulletin from './Bulletin';
+import dummy from '../../dummy/bulletin.json';
+import {
+  sortBulletinList,
+  sortedDefaultByOwner,
+} from '../../utils/sortBulletinList';
+import { BulletinType } from '../../types/Bulletin';
+
+interface BulletinListProps {
+  isMyPage?: boolean;
+}
+
+export default function BulletinList({ isMyPage }: BulletinListProps) {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const sortBy = searchParams.get('sort') as 'default' | 'view' | 'popular';
+
+  const onClickBulletin = (id: string | number) => navigate(`/board/${id}`);
+
+  // TODO: userId는 전역으로 관리 해야함
+  const userId = '자몽허니블랙티';
+  const data = isMyPage
+    ? sortedDefaultByOwner(userId, dummy)
+    : sortBulletinList(sortBy, dummy);
+
+  return (
+    <ul className="overflow-y-auto h-[calc(100%-4.8rem)]">
+      {data.map((item: BulletinType) => (
+        <li key={item.id} onClick={() => onClickBulletin(item.id)}>
+          <Bulletin
+            title={item.title}
+            content={item.content}
+            // time={item.time}
+            reactions={item.reactions}
+            userReaction={item.userReactions?.[item.authorId] ?? null}
+            isShowZero
+            isShowTime={isMyPage ? true : false}
+          />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -1,6 +1,6 @@
 import { useLocation } from 'react-router-dom';
 import Header from './header/Header';
-
+import dummy from '../../dummy/bulletin.json';
 interface LayoutProps {
   children: React.ReactNode;
 }
@@ -15,10 +15,17 @@ export default function Layout({ children }: LayoutProps) {
     '/bomb': <Header title="💣" />,
   };
 
-  // TODO: isOwner의 유무 처리 필요 => 데이터베이스 있을 때
+  // TODO: userId는 로그인한 유저의 _id
+  const userId = '자몽허니블랙티';
+
+  const pathPartList = pathname.split('/');
+  const postId = pathPartList[pathPartList.length - 1];
+  const isOwner = !!dummy.find(
+    (item) => item.id === postId && item.authorId === userId
+  );
   const dynamicHeader =
     pathname.startsWith('/board/') && !renderHeader[pathname] ? (
-      <Header title="대나무" isOwner />
+      <Header title="대나무" isOwner={isOwner} />
     ) : null;
 
   return (

--- a/src/pages/Board.tsx
+++ b/src/pages/Board.tsx
@@ -1,15 +1,13 @@
 import { useState, useEffect } from 'react';
 import Layout from '../components/common/Layout';
-import Bulletin from '../components/common/Bulletin';
-import dummy from '../dummy/bulletin.json';
 import BoardButtonList from '../components/BoardButtonList';
 import Modal from '../components/Modal';
-import { useNavigate } from 'react-router-dom';
+import BulletinList from '../components/common/BulletinList';
 
 export default function Board() {
   const [isOpenModal, setIsOpenModal] = useState(false);
   const [isBoardButtonList, setIsBoardButtonList] = useState(false);
-  const navigate = useNavigate();
+
   const toggleModal = () => setIsOpenModal(!isOpenModal);
   const closeBoardButtonList = () => setIsBoardButtonList(false);
   const openBoardButtonList = () => setIsBoardButtonList(true);
@@ -22,8 +20,6 @@ export default function Board() {
       document.body.style.overflow = '';
     };
   }, [isOpenModal]);
-
-  const onClickBulletin = (id: string | number) => navigate(`/board/${id}`);
 
   return (
     <Layout>
@@ -39,20 +35,7 @@ export default function Board() {
         closeBoardButtonList={closeBoardButtonList}
         isBoardButtonList={isBoardButtonList}
       />
-      <ul className="overflow-y-auto h-[calc(100%-4.8rem)]">
-        {dummy.map((item) => (
-          <li key={item.id} onClick={() => onClickBulletin(item.id)}>
-            <Bulletin
-              title={item.title}
-              content={item.content}
-              time={item.time}
-              reactions={item.reactions}
-              isShowZero
-              userReaction={item.userReactions?.[item.authorId] ?? null}
-            />
-          </li>
-        ))}
-      </ul>
+      <BulletinList />
     </Layout>
   );
 }

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,23 +1,12 @@
-import Bulletin from '../components/common/Bulletin';
+import BulletinList from '../components/common/BulletinList';
 import Layout from '../components/common/Layout';
 import UserProfile from '../components/UserProfile';
-import dummy from '../dummy/bulletin.json';
 
 export default function MyPage() {
   return (
     <Layout>
       <UserProfile isMypage />
-      <ul className="overflow-y-auto h-[calc(100%-10.1rem)]">
-        {dummy.map((item) => (
-          <Bulletin
-            key={item.id}
-            title={item.title}
-            content={item.content}
-            time={item.time}
-            isShowTime
-          />
-        ))}
-      </ul>
+      <BulletinList isMyPage />
     </Layout>
   );
 }

--- a/src/types/Bulletin.ts
+++ b/src/types/Bulletin.ts
@@ -13,3 +13,22 @@ export interface ReactionListEmojiType {
   '😀': number | string;
   '😡': number | string;
 }
+
+interface TimeStamp {
+  date: string;
+}
+
+interface UserReactions {
+  [key: string]: 'LIKE' | 'HEART' | 'SURPRISED' | 'LAUGH' | 'ANGRY' | null;
+}
+
+export interface BulletinType {
+  id: string;
+  title: string;
+  content: string;
+  timestamp: TimeStamp;
+  authorId: string;
+  viewCount: number;
+  reactions: ReactionListTextType;
+  userReactions: UserReactions;
+}

--- a/src/utils/sortBulletinList.ts
+++ b/src/utils/sortBulletinList.ts
@@ -1,0 +1,46 @@
+import { BulletinType, ReactionListTextType } from '../types/Bulletin';
+
+const sortedView = (data: BulletinType[]): BulletinType[] => {
+  return data.sort((a, b) => b.viewCount - a.viewCount);
+};
+
+const sum = (reactions: ReactionListTextType): number => {
+  const total = Object.values(reactions).reduce(
+    (acc: number, cur: number) => acc + cur,
+    0
+  );
+  return total;
+};
+
+const sortPopular = (data: BulletinType[]): BulletinType[] => {
+  return data.sort((a, b) => sum(b.reactions) - sum(a.reactions));
+};
+
+const sortedDefault = (data: BulletinType[]): BulletinType[] => {
+  return data.sort(
+    (a, b) =>
+      new Date(b.timestamp.date).getTime() -
+      new Date(a.timestamp.date).getTime()
+  );
+};
+
+export const sortedDefaultByOwner = (
+  userId: string,
+  data: BulletinType[]
+): BulletinType[] => {
+  return data.filter((item) => item.authorId === userId);
+};
+
+export const sortBulletinList = (
+  condition: 'default' | 'view' | 'popular' = 'default',
+  data: BulletinType[]
+): BulletinType[] => {
+  switch (condition) {
+    case 'popular':
+      return sortPopular(data);
+    case 'view':
+      return sortedView(data);
+    default:
+      return sortedDefault(data);
+  }
+};


### PR DESCRIPTION
### 🖼️ Screen shot

https://github.com/user-attachments/assets/df65ed6f-2ba6-4959-b820-7405774880d0


### ✅ 작업 내용

- 남은 헤더 기능 구현

### 📝 Details

- 게시글 리스트 컴포넌트 생성
- 게시글 정렬 방식에 따라 정렬
- 내가 작성한 게시글의 헤더에는 삭제하기 버튼이 존재

### ⚠️ 주의사항

- 아직 백엔드 호출 없음
